### PR TITLE
Photo gallery loading fixes + Work for Hire page

### DIFF
--- a/public/reddit-research/index.html
+++ b/public/reddit-research/index.html
@@ -1,0 +1,1373 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reddit Research Assistant — A research tool for Reddit threads</title>
+  <meta name="description" content="A browser extension that turns Reddit threads into research briefs for content creators. Pain points, unanswered questions, content angles, and the five comments worth reading.">
+  <meta name="theme-color" content="#EFE9DC">
+  <meta property="og:title" content="Reddit Research Assistant">
+  <meta property="og:description" content="Read 5. Understand 500. Turn Reddit threads into structured research briefs.">
+  <meta property="og:type" content="website">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    /* ─────────────────────────────────────────────
+       RESET & ROOT
+       ───────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; }
+    html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    body { margin: 0; }
+
+    :root {
+      --paper:        #EFE9DC;
+      --paper-deep:   #E6DECB;
+      --paper-light:  #F6F1E5;
+      --doc:          #FAF6EA;
+      --ink:          #17120C;
+      --ink-dim:      #4B4133;
+      --ink-faded:    #857A63;
+      --stamp:        #C8301B;
+      --stamp-ink:    #9E2513;
+      --marker:       #F0CF3A;
+      --rule:         #17120C;
+      --rule-soft:    rgba(23, 18, 12, 0.14);
+
+      --f-display: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+      --f-body:    'Geist', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+      --f-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+
+      --page-max:  1280px;
+      --page-pad:  clamp(1.25rem, 5vw, 4rem);
+      --grid-gap:  clamp(1rem, 3vw, 2.5rem);
+    }
+
+    /* ─────────────────────────────────────────────
+       BASE
+       ───────────────────────────────────────────── */
+    body {
+      background: var(--paper);
+      color: var(--ink);
+      font-family: var(--f-body);
+      font-size: 17px;
+      line-height: 1.58;
+      font-feature-settings: "ss01", "ss02", "cv11";
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      text-rendering: optimizeLegibility;
+      overflow-x: hidden;
+    }
+
+    /* paper grain overlay */
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 1;
+      opacity: 0.35;
+      mix-blend-mode: multiply;
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.09 0 0 0 0 0.07 0 0 0 0 0.04 0 0 0 0.12 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+    }
+
+    a { color: inherit; text-decoration: none; }
+
+    ::selection { background: var(--stamp); color: var(--paper-light); }
+
+    /* ─────────────────────────────────────────────
+       TYPOGRAPHY PRIMITIVES
+       ───────────────────────────────────────────── */
+    h1, h2, h3, h4 {
+      font-family: var(--f-display);
+      font-weight: 400;
+      line-height: 1.02;
+      letter-spacing: -0.012em;
+      margin: 0;
+      color: var(--ink);
+    }
+
+    .eyebrow, .meta-label {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--ink-dim);
+    }
+
+    .serif-em { font-family: var(--f-display); font-style: italic; font-weight: 400; }
+
+    /* ─────────────────────────────────────────────
+       PAGE CHROME
+       ───────────────────────────────────────────── */
+    .page {
+      position: relative;
+      z-index: 2;
+      max-width: var(--page-max);
+      margin: 0 auto;
+      padding: 0 var(--page-pad);
+    }
+
+    /* ─────────────────────────────────────────────
+       MASTHEAD
+       ───────────────────────────────────────────── */
+    .masthead {
+      border-bottom: 1.5px solid var(--rule);
+      padding-top: clamp(1rem, 3vw, 1.75rem);
+      padding-bottom: clamp(1rem, 2.5vw, 1.5rem);
+      position: relative;
+    }
+
+    .masthead-meta {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      align-items: center;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px dashed var(--rule-soft);
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+    }
+
+    .masthead-meta .dot { color: var(--ink-faded); }
+    .masthead-meta .stamped {
+      color: var(--stamp);
+      border: 1px solid var(--stamp);
+      padding: 0.15rem 0.45rem 0.1rem;
+      transform: rotate(-1.5deg);
+      font-weight: 500;
+    }
+
+    .masthead-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      gap: 2rem;
+      padding-top: 0.9rem;
+    }
+
+    .wordmark {
+      display: flex;
+      flex-direction: column;
+      line-height: 0.88;
+    }
+
+    .wordmark-line-1 {
+      font-family: var(--f-display);
+      font-size: clamp(2rem, 4.5vw, 3.25rem);
+      letter-spacing: -0.02em;
+    }
+
+    .wordmark-line-2 {
+      font-family: var(--f-display);
+      font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+      font-style: italic;
+      color: var(--ink-dim);
+      margin-top: 0.1em;
+    }
+
+    nav.masthead-nav {
+      display: flex;
+      gap: clamp(1rem, 2.5vw, 2rem);
+      font-family: var(--f-mono);
+      font-size: 12px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      padding-bottom: 0.6em;
+    }
+
+    nav.masthead-nav a {
+      position: relative;
+      transition: color 0.2s ease;
+    }
+
+    nav.masthead-nav a::after {
+      content: "";
+      position: absolute;
+      left: 0; right: 0; bottom: -0.35em;
+      height: 1px;
+      background: currentColor;
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 0.3s ease;
+    }
+
+    nav.masthead-nav a:hover { color: var(--stamp); }
+    nav.masthead-nav a:hover::after { transform: scaleX(1); }
+
+    /* ─────────────────────────────────────────────
+       HERO
+       ───────────────────────────────────────────── */
+    .hero {
+      padding-top: clamp(3rem, 8vw, 7rem);
+      padding-bottom: clamp(4rem, 10vw, 8rem);
+      position: relative;
+    }
+
+    .hero-top-rule {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+      margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    .hero-top-rule .pills {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .pill {
+      padding: 0.25em 0.7em;
+      border: 1px solid var(--rule);
+      border-radius: 999px;
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    .pill-filled {
+      background: var(--ink);
+      color: var(--paper);
+      border-color: var(--ink);
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+      gap: clamp(2rem, 5vw, 5rem);
+      align-items: start;
+    }
+
+    @media (max-width: 900px) {
+      .hero-grid { grid-template-columns: 1fr; }
+    }
+
+    .hero-headline {
+      font-size: clamp(3.25rem, 8.5vw, 7.5rem);
+      line-height: 0.94;
+      letter-spacing: -0.025em;
+      margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+    }
+
+    .hero-headline .line { display: block; }
+    .hero-headline .line + .line { margin-top: -0.06em; }
+    .hero-headline em {
+      font-style: italic;
+      color: var(--stamp);
+    }
+    .hero-headline .num {
+      font-style: italic;
+      font-feature-settings: "onum";
+    }
+    .hero-headline .period { color: var(--stamp); }
+
+    .hero-sub {
+      font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+      line-height: 1.48;
+      color: var(--ink-dim);
+      max-width: 34em;
+      margin: 0 0 2rem 0;
+    }
+
+    .hero-sub .lead-cap {
+      font-family: var(--f-display);
+      font-size: 1.3em;
+      color: var(--ink);
+      font-weight: 400;
+    }
+
+    .cta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.85rem;
+      align-items: center;
+      margin-bottom: 1.75rem;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5em;
+      font-family: var(--f-body);
+      font-size: 15px;
+      font-weight: 500;
+      padding: 0.95em 1.35em;
+      border-radius: 2px;
+      transition: transform 0.18s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+      cursor: pointer;
+      letter-spacing: 0.01em;
+      border: 1.5px solid var(--ink);
+      line-height: 1;
+    }
+
+    .btn-primary {
+      background: var(--ink);
+      color: var(--paper-light);
+    }
+    .btn-primary:hover {
+      background: var(--stamp);
+      border-color: var(--stamp);
+      transform: translate(-1px, -1px);
+      box-shadow: 3px 3px 0 var(--ink);
+    }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--ink);
+    }
+    .btn-ghost:hover {
+      background: var(--ink);
+      color: var(--paper-light);
+      transform: translate(-1px, -1px);
+      box-shadow: 3px 3px 0 var(--stamp);
+    }
+
+    .btn .arrow {
+      display: inline-block;
+      transition: transform 0.2s ease;
+    }
+    .btn:hover .arrow { transform: translateX(3px); }
+
+    .btn-lg { font-size: 17px; padding: 1.1em 1.75em; }
+
+    .hero-caveat {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-faded);
+    }
+
+    .hero-caveat .sep { opacity: 0.5; }
+
+    /* ─────────────────────────────────────────────
+       BRIEF PREVIEW (signature element)
+       ───────────────────────────────────────────── */
+    .brief-doc {
+      background: var(--doc);
+      padding: clamp(1.5rem, 3vw, 2.25rem) clamp(1.25rem, 2.5vw, 1.75rem);
+      position: relative;
+      transform: rotate(0.6deg);
+      box-shadow:
+        0 1px 0 rgba(23, 18, 12, 0.06),
+        0 8px 20px -4px rgba(23, 18, 12, 0.1),
+        0 30px 60px -20px rgba(23, 18, 12, 0.22);
+      font-size: 14.5px;
+      line-height: 1.5;
+      max-width: 560px;
+      margin-left: auto;
+      border: 1px solid rgba(23, 18, 12, 0.08);
+    }
+
+    .brief-doc::before {
+      /* subtle paper texture via inner edge */
+      content: "";
+      position: absolute;
+      inset: 0;
+      border: 1px solid rgba(23, 18, 12, 0.04);
+      pointer-events: none;
+    }
+
+    .brief-stamp {
+      position: absolute;
+      top: -14px;
+      right: 1.5rem;
+      background: var(--paper);
+      border: 1.5px solid var(--stamp);
+      color: var(--stamp);
+      font-family: var(--f-mono);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      padding: 0.35em 0.75em 0.25em;
+      transform: rotate(-2deg);
+      z-index: 2;
+    }
+
+    .brief-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding-bottom: 0.75rem;
+      border-bottom: 1.5px solid var(--rule);
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+
+    .brief-head .title { color: var(--ink); font-weight: 500; }
+    .brief-head .sub { color: var(--ink-dim); }
+
+    .brief-thread {
+      font-family: var(--f-display);
+      font-size: 1.35rem;
+      line-height: 1.15;
+      margin: 0.85rem 0 0.3rem;
+      letter-spacing: -0.01em;
+    }
+
+    .brief-thread em { color: var(--ink-dim); }
+
+    .brief-meta {
+      font-family: var(--f-mono);
+      font-size: 10.5px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--ink-faded);
+      margin-bottom: 1.25rem;
+    }
+
+    .brief-section {
+      margin: 1.15rem 0;
+    }
+
+    .brief-section:not(:last-child) {
+      padding-bottom: 1.15rem;
+      border-bottom: 1px dashed var(--rule-soft);
+    }
+
+    .brief-section h4 {
+      font-family: var(--f-body);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--stamp);
+      margin-bottom: 0.55rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .brief-section h4 .sigil {
+      display: inline-block;
+      width: 0.9em;
+      text-align: center;
+      font-family: var(--f-display);
+      font-size: 1.15em;
+      color: var(--stamp);
+      font-style: italic;
+    }
+
+    .brief-section ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .brief-section li {
+      position: relative;
+      padding-left: 1.1em;
+      margin: 0.4em 0;
+      font-size: 14px;
+      line-height: 1.48;
+      color: var(--ink);
+    }
+
+    .brief-section li::before {
+      content: "—";
+      position: absolute;
+      left: 0;
+      color: var(--ink-faded);
+    }
+
+    .brief-section .attrib {
+      display: block;
+      font-family: var(--f-mono);
+      font-size: 10.5px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--ink-faded);
+      margin-top: 0.2em;
+    }
+
+    .brief-section .quote {
+      font-family: var(--f-display);
+      font-style: italic;
+      font-size: 1.04em;
+      color: var(--ink);
+    }
+
+    .brief-section .tag {
+      display: inline-block;
+      font-family: var(--f-mono);
+      font-size: 9.5px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--stamp);
+      border: 1px solid var(--stamp);
+      padding: 0.1em 0.5em 0.08em;
+      margin-right: 0.5em;
+      vertical-align: 1px;
+    }
+
+    .brief-foot {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-top: 0.9rem;
+      border-top: 1.5px solid var(--rule);
+      font-family: var(--f-mono);
+      font-size: 10.5px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+    }
+
+    .brief-foot .copy-hint {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4em;
+      color: var(--stamp);
+    }
+
+    /* ─────────────────────────────────────────────
+       SECTION SCAFFOLDING
+       ───────────────────────────────────────────── */
+    .section {
+      padding-top: clamp(4rem, 9vw, 7rem);
+      padding-bottom: clamp(4rem, 9vw, 7rem);
+      border-top: 1.5px solid var(--rule);
+      position: relative;
+    }
+
+    .section-mark {
+      display: flex;
+      align-items: baseline;
+      gap: 1rem;
+      margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+      padding-bottom: 0.85rem;
+      border-bottom: 1px dashed var(--rule-soft);
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+    }
+
+    .section-mark .num {
+      color: var(--stamp);
+      font-weight: 500;
+    }
+
+    .section-mark .right {
+      margin-left: auto;
+      color: var(--ink-faded);
+    }
+
+    .section h2 {
+      font-size: clamp(2.5rem, 5.5vw, 4.5rem);
+      line-height: 0.96;
+      letter-spacing: -0.02em;
+      max-width: 18ch;
+      margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+    }
+
+    .section h2 em {
+      font-style: italic;
+      color: var(--stamp);
+    }
+
+    /* ─────────────────────────────────────────────
+       "WHAT YOU GET" / DIFFERENTIATION
+       ───────────────────────────────────────────── */
+    .what-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+      gap: clamp(2rem, 5vw, 4.5rem);
+      align-items: start;
+    }
+
+    @media (max-width: 900px) {
+      .what-grid { grid-template-columns: 1fr; }
+    }
+
+    .what-copy p {
+      font-size: clamp(1.05rem, 1.3vw, 1.2rem);
+      line-height: 1.5;
+      color: var(--ink);
+      margin: 0 0 1rem 0;
+      max-width: 36ch;
+    }
+
+    .what-copy p.dim { color: var(--ink-dim); }
+
+    .what-copy .pull {
+      font-family: var(--f-display);
+      font-size: clamp(1.5rem, 3vw, 2.1rem);
+      line-height: 1.15;
+      color: var(--ink);
+      font-style: italic;
+      border-left: 3px solid var(--stamp);
+      padding-left: 1rem;
+      margin: 1.5rem 0;
+      max-width: 22ch;
+    }
+
+    /* ─────────────────────────────────────────────
+       HOW IT WORKS — STEPS
+       ───────────────────────────────────────────── */
+    .steps {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0;
+      border: 1.5px solid var(--rule);
+      border-bottom: none;
+    }
+
+    @media (max-width: 820px) {
+      .steps { grid-template-columns: 1fr; }
+      .step { border-right: 1.5px solid var(--rule); }
+    }
+
+    .step {
+      padding: clamp(1.5rem, 3vw, 2.25rem);
+      border-bottom: 1.5px solid var(--rule);
+      border-right: 1.5px solid var(--rule);
+      position: relative;
+      background: var(--paper-light);
+      transition: background 0.25s ease;
+    }
+
+    .step:last-child { border-right: none; }
+
+    @media (max-width: 820px) {
+      .step:last-child { border-right: 1.5px solid var(--rule); }
+    }
+
+    .step:hover { background: var(--doc); }
+
+    .step-num {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      color: var(--stamp);
+      font-weight: 500;
+      margin-bottom: 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+    }
+
+    .step-num::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: var(--rule-soft);
+    }
+
+    .step h3 {
+      font-family: var(--f-display);
+      font-size: clamp(1.75rem, 2.7vw, 2.1rem);
+      line-height: 1.05;
+      margin-bottom: 0.75rem;
+    }
+
+    .step h3 em { font-style: italic; color: var(--stamp); }
+
+    .step p {
+      font-size: 15px;
+      line-height: 1.55;
+      color: var(--ink-dim);
+      margin: 0;
+    }
+
+    .step code {
+      font-family: var(--f-mono);
+      font-size: 0.92em;
+      background: var(--paper-deep);
+      padding: 0.1em 0.35em;
+      border-radius: 2px;
+    }
+
+    /* ─────────────────────────────────────────────
+       DIFFERENTIATORS
+       ───────────────────────────────────────────── */
+    .diff-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: clamp(1.5rem, 3vw, 2.5rem);
+    }
+
+    @media (max-width: 820px) {
+      .diff-grid { grid-template-columns: 1fr; }
+    }
+
+    .diff-item {
+      padding-top: 1.25rem;
+      border-top: 1.5px solid var(--rule);
+      position: relative;
+    }
+
+    .diff-item::before {
+      content: "";
+      position: absolute;
+      top: -1.5px; left: 0;
+      width: 3rem;
+      height: 3px;
+      background: var(--stamp);
+    }
+
+    .diff-item h3 {
+      font-family: var(--f-display);
+      font-size: clamp(1.5rem, 2.5vw, 1.9rem);
+      line-height: 1.1;
+      margin-bottom: 0.85rem;
+      max-width: 16ch;
+    }
+
+    .diff-item h3 em { font-style: italic; color: var(--stamp); }
+
+    .diff-item p {
+      font-size: 15.5px;
+      line-height: 1.55;
+      color: var(--ink-dim);
+      margin: 0;
+    }
+
+    .diff-item code {
+      font-family: var(--f-mono);
+      font-size: 0.9em;
+      background: var(--paper-deep);
+      padding: 0.05em 0.3em;
+    }
+
+    /* ─────────────────────────────────────────────
+       FAQ
+       ───────────────────────────────────────────── */
+    .faq {
+      margin: 0;
+      padding: 0;
+    }
+
+    .faq-item {
+      display: grid;
+      grid-template-columns: minmax(220px, 1fr) minmax(0, 2fr);
+      gap: clamp(1.25rem, 3vw, 3rem);
+      padding: clamp(1.25rem, 2.5vw, 1.75rem) 0;
+      border-bottom: 1px solid var(--rule-soft);
+      align-items: baseline;
+    }
+
+    .faq-item:last-child { border-bottom: none; }
+
+    .faq-item dt {
+      font-family: var(--f-display);
+      font-size: clamp(1.5rem, 2.2vw, 1.85rem);
+      line-height: 1.1;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+    }
+
+    .faq-item dd {
+      margin: 0;
+      font-size: 16px;
+      line-height: 1.58;
+      color: var(--ink-dim);
+      max-width: 46ch;
+    }
+
+    .faq-item dd code {
+      font-family: var(--f-mono);
+      font-size: 0.88em;
+      background: var(--paper-deep);
+      padding: 0.1em 0.35em;
+      color: var(--ink);
+    }
+
+    .faq-item dd a {
+      border-bottom: 1px solid var(--stamp);
+      color: var(--ink);
+      transition: color 0.2s;
+    }
+
+    .faq-item dd a:hover { color: var(--stamp); }
+
+    @media (max-width: 720px) {
+      .faq-item { grid-template-columns: 1fr; gap: 0.5rem; }
+    }
+
+    /* ─────────────────────────────────────────────
+       FINAL CTA
+       ───────────────────────────────────────────── */
+    .final-cta {
+      text-align: center;
+      padding-top: clamp(5rem, 10vw, 8rem);
+      padding-bottom: clamp(4rem, 8vw, 6rem);
+      border-top: 1.5px solid var(--rule);
+      position: relative;
+    }
+
+    .final-cta .eyebrow {
+      display: block;
+      margin-bottom: 1.25rem;
+      color: var(--stamp);
+    }
+
+    .final-cta h2 {
+      font-size: clamp(3rem, 7vw, 6rem);
+      line-height: 0.96;
+      letter-spacing: -0.025em;
+      margin: 0 auto 1.5rem;
+      max-width: 14ch;
+    }
+
+    .final-cta h2 em {
+      font-style: italic;
+      color: var(--stamp);
+    }
+
+    .final-cta p {
+      font-size: clamp(1.05rem, 1.4vw, 1.2rem);
+      line-height: 1.5;
+      color: var(--ink-dim);
+      max-width: 36ch;
+      margin: 0 auto 2.25rem;
+    }
+
+    /* ─────────────────────────────────────────────
+       FOOTER
+       ───────────────────────────────────────────── */
+    .footer {
+      border-top: 1.5px solid var(--rule);
+      padding-top: clamp(2.5rem, 5vw, 3.5rem);
+      padding-bottom: clamp(2rem, 4vw, 3rem);
+      font-size: 14px;
+    }
+
+    .footer-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr);
+      gap: clamp(1.5rem, 3vw, 3rem);
+      align-items: start;
+    }
+
+    @media (max-width: 780px) {
+      .footer-grid { grid-template-columns: 1fr 1fr; }
+    }
+
+    .footer-wordmark {
+      font-family: var(--f-display);
+      font-size: 1.5rem;
+      line-height: 1;
+      margin-bottom: 0.4rem;
+    }
+
+    .footer-wordmark em { font-style: italic; color: var(--ink-dim); }
+
+    .footer-note {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--ink-faded);
+    }
+
+    .footer-label {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink);
+      margin-bottom: 0.85rem;
+    }
+
+    .footer ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .footer ul a {
+      color: var(--ink-dim);
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s, color 0.2s;
+      padding-bottom: 1px;
+    }
+
+    .footer ul a:hover {
+      color: var(--ink);
+      border-color: var(--stamp);
+    }
+
+    .footer-colophon {
+      font-family: var(--f-display);
+      font-style: italic;
+      font-size: 15px;
+      color: var(--ink-dim);
+      line-height: 1.35;
+    }
+
+    /* ─────────────────────────────────────────────
+       ENTRY ANIMATIONS
+       ───────────────────────────────────────────── */
+    @keyframes riseIn {
+      from { opacity: 0; transform: translateY(14px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes rotateIn {
+      from { opacity: 0; transform: rotate(-2deg) translateY(14px); }
+      to   { opacity: 1; transform: rotate(0.6deg) translateY(0); }
+    }
+
+    @keyframes stampIn {
+      0%   { opacity: 0; transform: rotate(6deg) scale(1.4); }
+      60%  { opacity: 1; transform: rotate(-4deg) scale(0.95); }
+      100% { opacity: 1; transform: rotate(-2deg) scale(1); }
+    }
+
+    .anim-rise {
+      opacity: 0;
+      animation: riseIn 0.8s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+    }
+
+    .hero-top-rule        { animation-delay: 0.05s; }
+    .hero-headline .l1    { animation-delay: 0.15s; }
+    .hero-headline .l2    { animation-delay: 0.3s; }
+    .hero-sub             { animation-delay: 0.45s; }
+    .cta-row              { animation-delay: 0.6s; }
+    .hero-caveat          { animation-delay: 0.72s; }
+
+    .hero .brief-doc {
+      opacity: 0;
+      animation: rotateIn 1s cubic-bezier(0.2, 0.7, 0.2, 1) 0.4s forwards;
+    }
+
+    .hero .brief-stamp {
+      opacity: 0;
+      animation: stampIn 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 1.2s forwards;
+    }
+
+    /* scroll-reveal */
+    .reveal {
+      opacity: 0;
+      transform: translateY(20px);
+      transition: opacity 0.8s cubic-bezier(0.2, 0.7, 0.2, 1), transform 0.8s cubic-bezier(0.2, 0.7, 0.2, 1);
+    }
+
+    .reveal.in {
+      opacity: 1;
+      transform: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+      .reveal { opacity: 1; transform: none; }
+      .brief-doc { transform: rotate(0.6deg); opacity: 1; }
+    }
+
+    /* ─────────────────────────────────────────────
+       RESPONSIVE TOUCH-UPS
+       ───────────────────────────────────────────── */
+    @media (max-width: 640px) {
+      .masthead-row { flex-direction: column; align-items: flex-start; gap: 1rem; }
+      nav.masthead-nav { flex-wrap: wrap; padding-bottom: 0; }
+      .brief-doc { max-width: 100%; margin-top: 3rem; }
+      .hero-caveat { gap: 0.4rem; }
+      .hero-caveat .sep { display: none; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════════════════
+     MASTHEAD
+     ══════════════════════════════════════════════════ -->
+<header class="page masthead">
+  <div class="masthead-meta">
+    <span>FILE NO. RRA—001</span>
+    <span class="dot">·</span>
+    <span>VOL. I · ISSUE 1</span>
+    <span class="dot">·</span>
+    <span>APRIL MMXXVI</span>
+    <span class="dot">·</span>
+    <span class="stamped">BETA</span>
+  </div>
+  <div class="masthead-row">
+    <a href="./" class="wordmark">
+      <span class="wordmark-line-1">Reddit Research Assistant</span>
+      <span class="wordmark-line-2"><em>a research tool for content creators</em></span>
+    </a>
+    <nav class="masthead-nav">
+      <a href="#brief">The brief</a>
+      <a href="#how">How</a>
+      <a href="#faq">FAQ</a>
+      <a href="privacy/">Privacy</a>
+    </nav>
+  </div>
+</header>
+
+<main class="page">
+
+  <!-- ══════════════════════════════════════════════════
+       HERO
+       ══════════════════════════════════════════════════ -->
+  <section class="hero">
+    <div class="hero-top-rule anim-rise">
+      <span>§ 00 — DISPATCH</span>
+      <div class="pills">
+        <span class="pill">Browser Extension</span>
+        <span class="pill">Chrome · MV3</span>
+        <span class="pill pill-filled">Free · BYO Key</span>
+      </div>
+    </div>
+
+    <div class="hero-grid">
+      <div>
+        <h1 class="hero-headline">
+          <span class="line anim-rise l1">Read <span class="num">5</span><span class="period">.</span></span>
+          <span class="line anim-rise l2"><em>Understand</em> <span class="num">500</span><span class="period">.</span></span>
+        </h1>
+        <p class="hero-sub anim-rise">
+          <span class="lead-cap">A</span> browser extension that turns Reddit threads into structured research briefs: the five comments worth reading, the pain points worth writing about, the questions nobody answered.
+        </p>
+        <div class="cta-row anim-rise">
+          <a href="#" class="btn btn-primary" id="cta-install">
+            Install for Chrome
+            <span class="arrow">→</span>
+          </a>
+          <a href="#brief" class="btn btn-ghost">
+            See a sample brief
+          </a>
+        </div>
+        <div class="hero-caveat anim-rise">
+          <span>Free</span>
+          <span class="sep">·</span>
+          <span>Bring your own API key</span>
+          <span class="sep">·</span>
+          <span>Claude / Gemini / GPT</span>
+        </div>
+      </div>
+
+      <!-- Signature element: mock research brief -->
+      <aside>
+        <article class="brief-doc" aria-label="Example research brief">
+          <div class="brief-stamp">◌ DECLASSIFIED</div>
+
+          <header class="brief-head">
+            <span class="title">Research Brief</span>
+            <span class="sub">r/marketing</span>
+          </header>
+
+          <h3 class="brief-thread">"What's actually working for <em>organic</em> LinkedIn reach in 2026?"</h3>
+          <div class="brief-meta">518 comments · analyzed 2026-04-21 · claude sonnet 4.6</div>
+
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Key Pain Points</h4>
+            <ul>
+              <li>Algorithm favoring hot-takes over substance, burying thoughtful posts</li>
+              <li>Engagement pods skewing the signal on what's genuinely working</li>
+              <li>Posting-cadence burnout with no clear attribution to pipeline</li>
+            </ul>
+          </div>
+
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Unanswered Questions</h4>
+            <ul>
+              <li>Does commenting on buyers' posts move the needle more than your own?</li>
+              <li>How to separate brand lift from inbound leads in LinkedIn analytics?</li>
+            </ul>
+          </div>
+
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Content Angles</h4>
+            <ul>
+              <li>"Posting less, commenting more: a 30-day flywheel"</li>
+              <li>"The slow death of the thought-leader carousel"</li>
+            </ul>
+          </div>
+
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Interesting Comments</h4>
+            <ul>
+              <li>
+                <span class="quote">"We stopped posting and spent a month commenting on our buyers' posts instead. Inbound DMs went up 40%…"</span>
+                <span class="attrib">— u/b2b_cmo_21 · experience-driven</span>
+              </li>
+              <li>
+                <span class="tag">buried gem</span>6 upvotes, shares 12-month attribution: 3M impressions, 40 real conversations
+              </li>
+            </ul>
+          </div>
+
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Trend Signals</h4>
+            <ul>
+              <li>Attention shifting from post creation to comment engagement in buyers' feeds</li>
+            </ul>
+          </div>
+
+          <footer class="brief-foot">
+            <span>End of brief</span>
+            <span class="copy-hint">⌘ copy as markdown</span>
+          </footer>
+        </article>
+      </aside>
+    </div>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════
+       WHAT YOU GET
+       ══════════════════════════════════════════════════ -->
+  <section class="section" id="brief">
+    <div class="section-mark reveal">
+      <span><span class="num">§ 01</span> &nbsp; What you get</span>
+      <span class="right">Five comments from five hundred</span>
+    </div>
+
+    <div class="what-grid">
+      <div class="what-copy reveal">
+        <h2>The thread, <em>briefed.</em></h2>
+        <p>Each brief exposes what a thread is <em>actually</em> telling you: the pain you can write about, the question nobody answered, the comment buried in a twelve-reply chain that reframes the whole thread.</p>
+        <blockquote class="pull">Five comments, chosen for what they know.</blockquote>
+        <p class="dim">Every brief follows the same five-part template. Copy as markdown. Paste into Obsidian, Notion, or your content doc. The structure travels with it.</p>
+      </div>
+
+      <div class="reveal" style="transition-delay: 0.1s;">
+        <!-- Static secondary preview styled smaller as a reference card -->
+        <div class="brief-doc" style="transform: rotate(-0.7deg); max-width: 100%; margin: 0; background: var(--paper-light);">
+          <header class="brief-head">
+            <span class="title">Brief template</span>
+            <span class="sub">5 sections</span>
+          </header>
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Key Pain Points</h4>
+            <ul>
+              <li>Problems users express, surfaced as writable content topics.</li>
+            </ul>
+          </div>
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Unanswered Questions</h4>
+            <ul>
+              <li>Knowledge gaps where the thread's answers fell short.</li>
+            </ul>
+          </div>
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Content Angles</h4>
+            <ul>
+              <li>Alternative framings you could write as articles or videos.</li>
+            </ul>
+          </div>
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Interesting Comments</h4>
+            <ul>
+              <li>Five comments curated for experience, expertise, contrarian takes, or buried insight.</li>
+            </ul>
+          </div>
+          <div class="brief-section">
+            <h4><span class="sigil">§</span>Trend Signals</h4>
+            <ul>
+              <li>Shifts in sentiment, emerging language, new questions surfacing.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════
+       HOW IT WORKS
+       ══════════════════════════════════════════════════ -->
+  <section class="section" id="how">
+    <div class="section-mark reveal">
+      <span><span class="num">§ 02</span> &nbsp; How it works</span>
+      <span class="right">Three steps · all local</span>
+    </div>
+
+    <h2 class="reveal">Three steps. <em>All in your browser.</em></h2>
+
+    <div class="steps reveal">
+      <div class="step">
+        <div class="step-num"><span>01</span></div>
+        <h3>Install the extension</h3>
+        <p>One click from the Chrome Web Store. The extension asks for the minimum permissions to read Reddit threads.</p>
+      </div>
+      <div class="step">
+        <div class="step-num"><span>02</span></div>
+        <h3>Paste an API key</h3>
+        <p>Choose Anthropic, Google, or OpenAI. Your key stays in <code>chrome.storage.local</code>, readable only to this extension.</p>
+      </div>
+      <div class="step">
+        <div class="step-num"><span>03</span></div>
+        <h3>Click to generate</h3>
+        <p>On any Reddit thread, click <em>Research Brief</em>. The model extracts, curates, and writes the brief in about 15 seconds.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════
+       WHAT MAKES IT DIFFERENT
+       ══════════════════════════════════════════════════ -->
+  <section class="section">
+    <div class="section-mark reveal">
+      <span><span class="num">§ 03</span> &nbsp; What makes it different</span>
+      <span class="right">Built as a research tool</span>
+    </div>
+
+    <h2 class="reveal">The comments worth reading <em>live below</em> the top upvotes.</h2>
+
+    <div class="diff-grid reveal">
+      <div class="diff-item">
+        <h3>Ranked by <em>insight</em></h3>
+        <p>The top five surface experience-driven accounts, contrarian-but-thoughtful takes, and buried gems with four upvotes and domain expertise. The comments a good researcher would quote.</p>
+      </div>
+      <div class="diff-item">
+        <h3>Structured for content <em>work</em></h3>
+        <p>Every brief follows the same five-section template. Skim twenty in a row and know exactly where to look. Export as markdown; the structure travels with it.</p>
+      </div>
+      <div class="diff-item">
+        <h3>Runs in your browser. Keys stay <em>local.</em></h3>
+        <p>Your key lives in <code>chrome.storage.local</code> and talks only to the LLM provider you chose. Everything else runs on your machine.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════
+       FAQ
+       ══════════════════════════════════════════════════ -->
+  <section class="section" id="faq">
+    <div class="section-mark reveal">
+      <span><span class="num">§ 04</span> &nbsp; Questions</span>
+      <span class="right">Frequently asked</span>
+    </div>
+
+    <h2 class="reveal">Answers, <em>filed.</em></h2>
+
+    <dl class="faq reveal">
+      <div class="faq-item">
+        <dt>What does it cost?</dt>
+        <dd>The extension is free. You pay your LLM provider directly for model usage, typically a few cents per brief.</dd>
+      </div>
+      <div class="faq-item">
+        <dt>Which models does it support?</dt>
+        <dd>Anthropic (Claude Sonnet 4.6, default), Google (Gemini 2.5 Flash), and OpenAI (GPT-4o). Swap between them in settings. Bring an API key for whichever you pick.</dd>
+      </div>
+      <div class="faq-item">
+        <dt>Is my data private?</dt>
+        <dd>Yes. The extension runs entirely in your browser. Thread contents travel directly to the provider you chose, and keys stay in <code>chrome.storage.local</code> on your machine. <a href="privacy/">Read the full privacy policy →</a></dd>
+      </div>
+      <div class="faq-item">
+        <dt>Does it work on old Reddit?</dt>
+        <dd>Yes. Both <code>old.reddit.com</code> and new Reddit are supported, with separate extractors and fallback selectors so each keeps working when the other's layout shifts.</dd>
+      </div>
+      <div class="faq-item">
+        <dt>What about huge threads?</dt>
+        <dd>Large threads get pre-filtered client-side to drop deleted, low-effort, and spam comments, then fit to a token budget so the brief stays fast and cheap. You'll see a warning if comments are still loading below the fold.</dd>
+      </div>
+      <div class="faq-item">
+        <dt>Firefox? Safari?</dt>
+        <dd>Not yet. V1 is Chromium-only. Firefox and Safari support is planned.</dd>
+      </div>
+      <div class="faq-item">
+        <dt>Why client-side only?</dt>
+        <dd>Deliberate. Running in your browser keeps your research on your machine, removes per-user infrastructure cost, and lets the extension stay free.</dd>
+      </div>
+    </dl>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════
+       FINAL CTA
+       ══════════════════════════════════════════════════ -->
+  <section class="final-cta">
+    <span class="eyebrow">§ End of dispatch</span>
+    <h2 class="reveal">Read the thread, <em>once</em>.</h2>
+    <p class="reveal">Free. Bring your own key. Install in a click.</p>
+    <a href="#" class="btn btn-primary btn-lg reveal">
+      Install for Chrome
+      <span class="arrow">→</span>
+    </a>
+  </section>
+
+</main>
+
+<!-- ══════════════════════════════════════════════════
+     FOOTER
+     ══════════════════════════════════════════════════ -->
+<footer class="page footer">
+  <div class="footer-grid">
+    <div>
+      <div class="footer-wordmark">Reddit Research <em>Assistant</em></div>
+      <div class="footer-note">V.1.0 · Beta · MMXXVI</div>
+    </div>
+    <div>
+      <div class="footer-label">Resources</div>
+      <ul>
+        <li><a href="privacy/">Privacy policy</a></li>
+        <li><a href="#" id="footer-install">Chrome Web Store</a></li>
+        <li><a href="#faq">FAQ</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="footer-label">Contact</div>
+      <ul>
+        <li><a href="mailto:bj.blayney@gmail.com">bj.blayney@gmail.com</a></li>
+      </ul>
+    </div>
+    <div class="footer-colophon">
+      Set in Instrument Serif, Geist &amp; JetBrains Mono. A solo project by BJ Blayney.
+    </div>
+  </div>
+</footer>
+
+<script>
+  // Scroll-triggered reveal
+  (function() {
+    const reveals = document.querySelectorAll('.reveal');
+    if (!('IntersectionObserver' in window)) {
+      reveals.forEach(el => el.classList.add('in'));
+      return;
+    }
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('in');
+          io.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '0px 0px -10% 0px', threshold: 0.05 });
+    reveals.forEach(el => io.observe(el));
+  })();
+
+  // Placeholder handler for install CTA until Web Store URL is live
+  (function() {
+    const ctas = document.querySelectorAll('[id^="cta-install"], #footer-install, .btn-primary[href="#"]');
+    ctas.forEach(el => {
+      if (el.getAttribute('href') !== '#') return;
+      el.addEventListener('click', (e) => {
+        e.preventDefault();
+        const original = el.innerHTML;
+        el.innerHTML = 'Coming to the Chrome Web Store soon <span class="arrow">◌</span>';
+        setTimeout(() => { el.innerHTML = original; }, 2400);
+      });
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/public/reddit-research/privacy/index.html
+++ b/public/reddit-research/privacy/index.html
@@ -1,0 +1,550 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — Reddit Research Assistant</title>
+  <meta name="description" content="Privacy policy for the Reddit Research Assistant browser extension. Client-side operation. Keys stay in your browser.">
+  <meta name="theme-color" content="#EFE9DC">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    body { margin: 0; }
+
+    :root {
+      --paper:        #EFE9DC;
+      --paper-deep:   #E6DECB;
+      --paper-light:  #F6F1E5;
+      --doc:          #FAF6EA;
+      --ink:          #17120C;
+      --ink-dim:      #4B4133;
+      --ink-faded:    #857A63;
+      --stamp:        #C8301B;
+      --rule:         #17120C;
+      --rule-soft:    rgba(23, 18, 12, 0.14);
+
+      --f-display: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+      --f-body:    'Geist', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+      --f-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+
+      --page-max:  860px;
+      --page-pad:  clamp(1.25rem, 5vw, 3rem);
+    }
+
+    body {
+      background: var(--paper);
+      color: var(--ink);
+      font-family: var(--f-body);
+      font-size: 17px;
+      line-height: 1.62;
+      font-feature-settings: "ss01", "ss02", "cv11";
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      text-rendering: optimizeLegibility;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 1;
+      opacity: 0.3;
+      mix-blend-mode: multiply;
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.09 0 0 0 0 0.07 0 0 0 0 0.04 0 0 0 0.12 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+    }
+
+    a { color: inherit; text-decoration: none; }
+    ::selection { background: var(--stamp); color: var(--paper-light); }
+
+    .page {
+      position: relative;
+      z-index: 2;
+      max-width: var(--page-max);
+      margin: 0 auto;
+      padding: 0 var(--page-pad);
+    }
+
+    /* ───── MASTHEAD (simplified) ───── */
+    .masthead {
+      border-bottom: 1.5px solid var(--rule);
+      padding-top: clamp(1rem, 3vw, 1.75rem);
+      padding-bottom: 1rem;
+    }
+
+    .masthead-meta {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      align-items: center;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px dashed var(--rule-soft);
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+    }
+
+    .masthead-meta .dot { color: var(--ink-faded); }
+
+    .masthead-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding-top: 0.9rem;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .wordmark {
+      font-family: var(--f-display);
+      font-size: clamp(1.35rem, 2.2vw, 1.7rem);
+      letter-spacing: -0.01em;
+    }
+
+    .wordmark em {
+      font-style: italic;
+      color: var(--ink-dim);
+    }
+
+    .back-link {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+      transition: color 0.2s;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .back-link:hover { color: var(--stamp); }
+
+    .back-link .arrow {
+      transition: transform 0.2s ease;
+    }
+
+    .back-link:hover .arrow { transform: translateX(-3px); }
+
+    /* ───── DOCUMENT HEADER ───── */
+    .doc-head {
+      padding-top: clamp(3rem, 7vw, 5rem);
+      padding-bottom: clamp(2rem, 4vw, 3rem);
+    }
+
+    .doc-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 1rem;
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+      padding-bottom: 1rem;
+      border-bottom: 1px dashed var(--rule-soft);
+      margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+      flex-wrap: wrap;
+    }
+
+    .doc-meta .num { color: var(--stamp); font-weight: 500; }
+
+    h1.doc-title {
+      font-family: var(--f-display);
+      font-size: clamp(2.75rem, 6.5vw, 5rem);
+      line-height: 0.96;
+      letter-spacing: -0.025em;
+      font-weight: 400;
+      margin: 0 0 1rem 0;
+      color: var(--ink);
+    }
+
+    h1.doc-title em {
+      font-style: italic;
+      color: var(--stamp);
+    }
+
+    .doc-subtitle {
+      font-size: clamp(1.05rem, 1.4vw, 1.2rem);
+      line-height: 1.5;
+      color: var(--ink-dim);
+      margin: 0;
+      font-family: var(--f-display);
+      font-style: italic;
+      max-width: 40ch;
+    }
+
+    /* ───── TL;DR CALLOUT ───── */
+    .tldr {
+      background: var(--doc);
+      border: 1.5px solid var(--rule);
+      padding: clamp(1.5rem, 3vw, 2rem);
+      margin: clamp(2rem, 4vw, 3rem) 0;
+      position: relative;
+    }
+
+    .tldr::before {
+      content: "Summary";
+      position: absolute;
+      top: -11px;
+      left: 1.5rem;
+      background: var(--paper);
+      color: var(--stamp);
+      font-family: var(--f-mono);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      padding: 0 0.65em;
+    }
+
+    .tldr ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .tldr li {
+      font-family: var(--f-display);
+      font-size: clamp(1.2rem, 1.9vw, 1.45rem);
+      line-height: 1.3;
+      padding: 0.6em 0 0.6em 1.6em;
+      border-bottom: 1px dashed var(--rule-soft);
+      position: relative;
+    }
+
+    .tldr li:last-child { border-bottom: none; padding-bottom: 0; }
+    .tldr li:first-child { padding-top: 0.1em; }
+
+    .tldr li::before {
+      content: "§";
+      position: absolute;
+      left: 0;
+      top: 0.6em;
+      color: var(--stamp);
+      font-style: italic;
+    }
+
+    .tldr li:first-child::before { top: 0.1em; }
+
+    .tldr li em {
+      font-style: italic;
+      color: var(--stamp);
+    }
+
+    /* ───── CLAUSES ───── */
+    .clauses {
+      margin: clamp(2.5rem, 5vw, 4rem) 0;
+    }
+
+    .clause {
+      display: grid;
+      grid-template-columns: 90px minmax(0, 1fr);
+      gap: clamp(1rem, 2.5vw, 2rem);
+      padding: clamp(1.5rem, 3vw, 2rem) 0;
+      border-top: 1px solid var(--rule-soft);
+    }
+
+    .clause:first-child { border-top: 1.5px solid var(--rule); }
+    .clause:last-child { border-bottom: 1.5px solid var(--rule); }
+
+    @media (max-width: 640px) {
+      .clause { grid-template-columns: 1fr; gap: 0.5rem; }
+    }
+
+    .clause-num {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--stamp);
+      font-weight: 500;
+      padding-top: 0.6em;
+    }
+
+    .clause-body h2 {
+      font-family: var(--f-display);
+      font-size: clamp(1.6rem, 2.6vw, 2rem);
+      line-height: 1.1;
+      letter-spacing: -0.01em;
+      font-weight: 400;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .clause-body h2 em {
+      font-style: italic;
+      color: var(--stamp);
+    }
+
+    .clause-body p {
+      font-size: 16.5px;
+      line-height: 1.6;
+      color: var(--ink-dim);
+      margin: 0 0 0.85em 0;
+    }
+
+    .clause-body p:last-child { margin-bottom: 0; }
+
+    .clause-body p code {
+      font-family: var(--f-mono);
+      font-size: 0.9em;
+      background: var(--paper-deep);
+      padding: 0.1em 0.4em;
+      color: var(--ink);
+    }
+
+    .clause-body ul {
+      list-style: none;
+      padding: 0;
+      margin: 0.5em 0 0.85em 0;
+    }
+
+    .clause-body ul li {
+      position: relative;
+      padding-left: 1.1em;
+      margin: 0.35em 0;
+      font-size: 16.5px;
+      line-height: 1.55;
+      color: var(--ink-dim);
+    }
+
+    .clause-body ul li::before {
+      content: "—";
+      position: absolute;
+      left: 0;
+      color: var(--ink-faded);
+    }
+
+    .clause-body ul li strong {
+      font-weight: 500;
+      color: var(--ink);
+    }
+
+    .clause-body a {
+      border-bottom: 1px solid var(--stamp);
+      color: var(--ink);
+      transition: color 0.2s;
+    }
+
+    .clause-body a:hover { color: var(--stamp); }
+
+    /* ───── FOOTER ───── */
+    .footer {
+      border-top: 1.5px solid var(--rule);
+      padding-top: clamp(2rem, 4vw, 3rem);
+      padding-bottom: clamp(2rem, 4vw, 3rem);
+      margin-top: clamp(2rem, 4vw, 3rem);
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .footer-note {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--ink-faded);
+    }
+
+    .footer-colophon {
+      font-family: var(--f-display);
+      font-style: italic;
+      font-size: 15px;
+      color: var(--ink-dim);
+    }
+
+    .footer a {
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s, color 0.2s;
+    }
+
+    .footer a:hover {
+      color: var(--stamp);
+      border-color: var(--stamp);
+    }
+
+    /* ───── ANIMATIONS ───── */
+    @keyframes riseIn {
+      from { opacity: 0; transform: translateY(10px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    .anim-rise {
+      opacity: 0;
+      animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+    }
+
+    .doc-meta       { animation-delay: 0.05s; }
+    h1.doc-title    { animation-delay: 0.15s; }
+    .doc-subtitle   { animation-delay: 0.25s; }
+    .tldr           { animation-delay: 0.4s; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+
+<header class="page masthead">
+  <div class="masthead-meta">
+    <span>FILE NO. RRA—001 / APPENDIX A</span>
+    <span class="dot">·</span>
+    <span>PRIVACY DISCLOSURE</span>
+    <span class="dot">·</span>
+    <span>EFFECTIVE 2026-04-21</span>
+  </div>
+  <div class="masthead-row">
+    <a href="../" class="wordmark">Reddit Research <em>Assistant</em></a>
+    <a href="../" class="back-link">
+      <span class="arrow">←</span>
+      Back to overview
+    </a>
+  </div>
+</header>
+
+<main class="page">
+
+  <section class="doc-head">
+    <div class="doc-meta anim-rise">
+      <span><span class="num">§ 00</span> &nbsp; Document</span>
+      <span>Version 1.0 · Effective April 21, 2026</span>
+    </div>
+    <h1 class="doc-title anim-rise">Privacy <em>policy</em>.</h1>
+    <p class="doc-subtitle anim-rise">Your research stays on your machine. The extension runs entirely in your browser, with your own API key.</p>
+  </section>
+
+  <aside class="tldr anim-rise">
+    <ul>
+      <li>Your API key is stored <em>only</em> in your browser's local storage.</li>
+      <li>Thread contents go <em>directly</em> from your browser to your chosen LLM provider.</li>
+      <li>The extension runs <em>entirely</em> in your browser, on your own machine.</li>
+      <li>It reads <em>only</em> the Reddit pages you're already viewing.</li>
+    </ul>
+  </aside>
+
+  <section class="clauses">
+
+    <article class="clause">
+      <div class="clause-num">§ 01</div>
+      <div class="clause-body">
+        <h2>Who we are.</h2>
+        <p>Reddit Research Assistant is a browser extension built and operated by BJ Blayney, a solo developer. This policy describes what the extension does with data. It does not apply to the LLM providers whose keys you supply; those are governed by their own policies.</p>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 02</div>
+      <div class="clause-body">
+        <h2>Data <em>handling.</em></h2>
+        <p>How the extension operates, in plain terms:</p>
+        <ul>
+          <li><strong>Client-side operation.</strong> The extension runs entirely in your browser. No server we operate receives, stores, or processes your data.</li>
+          <li><strong>Free of analytics.</strong> The build ships without pageview trackers, event reporters, or third-party analytics SDKs.</li>
+          <li><strong>Account-free.</strong> Installation alone is sufficient. No sign-up, login, or user identifier.</li>
+          <li><strong>Nothing collected, nothing sold.</strong> Because the extension collects no user data, there is nothing for us to sell or share.</li>
+        </ul>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 03</div>
+      <div class="clause-body">
+        <h2>What the extension <em>does</em> access.</h2>
+        <p>When you are on a Reddit thread and click <em>Generate Research Brief</em>, the extension:</p>
+        <ul>
+          <li>Reads the visible post and comments from the Reddit page you are currently viewing. Standard DOM access, limited to what you can already see.</li>
+          <li>Sends that content, along with a structured prompt, directly to the LLM provider (Anthropic, Google, or OpenAI) that you configured.</li>
+          <li>Receives the provider's response and renders it as an overlay on the page.</li>
+        </ul>
+        <p>No data from other tabs, other sites, or your browsing history is read. Host permissions are limited to <code>*.reddit.com</code> and the API endpoints of the configured LLM providers.</p>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 04</div>
+      <div class="clause-body">
+        <h2>Your API key.</h2>
+        <p>The extension stores your API key using the browser's <code>chrome.storage.local</code> API. That storage is:</p>
+        <ul>
+          <li>Local to your machine. It does not sync, leave your device, or get transmitted anywhere by us.</li>
+          <li>Readable only by this extension.</li>
+          <li>Cleared if you uninstall the extension.</li>
+        </ul>
+        <p>When you trigger a brief, the key is attached to the outgoing request to the LLM provider you chose. It is not sent anywhere else.</p>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 05</div>
+      <div class="clause-body">
+        <h2>Third-party providers.</h2>
+        <p>To generate a brief, the extension calls the API of whichever LLM provider you selected. Your prompt (which includes the Reddit thread content) and their response pass between your browser and their servers.</p>
+        <p>These providers have their own privacy policies and data-retention practices. Please review them:</p>
+        <ul>
+          <li><a href="https://www.anthropic.com/legal/privacy" target="_blank" rel="noopener">Anthropic Privacy Policy</a></li>
+          <li><a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google Privacy Policy</a> (governs the Gemini API)</li>
+          <li><a href="https://openai.com/policies/privacy-policy" target="_blank" rel="noopener">OpenAI Privacy Policy</a></li>
+        </ul>
+        <p>Some providers may offer data-use or training opt-outs at the API tier. Those are configured in your account with that provider, not inside this extension.</p>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 06</div>
+      <div class="clause-body">
+        <h2>Cookies &amp; tracking.</h2>
+        <p>The extension does not set cookies, does not load third-party scripts, and does not use fingerprinting techniques. This landing page (<code>bjblayney.github.io/reddit-research/</code>) is a static document served by GitHub Pages. See GitHub's <a href="https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement" target="_blank" rel="noopener">privacy statement</a> for their edge-layer logging.</p>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 07</div>
+      <div class="clause-body">
+        <h2>Children.</h2>
+        <p>The extension is not directed to children under 13 and does not knowingly collect any data from any user, regardless of age.</p>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 08</div>
+      <div class="clause-body">
+        <h2>Changes to this <em>policy</em>.</h2>
+        <p>If this policy changes materially, the effective date at the top of this document will be updated and the change will be called out in the extension's release notes. Because there is no account system, we have no way to email you; please check this page when upgrading the extension.</p>
+      </div>
+    </article>
+
+    <article class="clause">
+      <div class="clause-num">§ 09</div>
+      <div class="clause-body">
+        <h2>Contact.</h2>
+        <p>Questions, concerns, or requests regarding this policy or the extension's behavior:</p>
+        <p><a href="mailto:bj.blayney@gmail.com">bj.blayney@gmail.com</a></p>
+      </div>
+    </article>
+
+  </section>
+
+</main>
+
+<footer class="page footer">
+  <div class="footer-colophon">
+    Reddit Research Assistant · <a href="../">overview</a>
+  </div>
+  <div class="footer-note">V.1.0 · Effective 2026-04-21</div>
+</footer>
+
+</body>
+</html>

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -4,6 +4,7 @@ import Admin from './Admin';
 import TitlePage from './TitlePage';
 import TableOfContents from './TableOfContents';
 import ChapterPage from './ChapterPage';
+import WorkPage from './WorkPage';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './firebase';
 
@@ -20,6 +21,7 @@ function AppRouter() {
         <Route path="/" element={<TitlePage />} />
         <Route path="/contents" element={<TableOfContents />} />
         <Route path="/chapter/:id" element={<ChapterPage />} />
+        <Route path="/work" element={<WorkPage />} />
         <Route path="/login" element={<Login />} />
         <Route path="/admin" element={user ? <Admin /> : <Navigate to="/login" />} />
       </Routes>

--- a/src/TableOfContents.js
+++ b/src/TableOfContents.js
@@ -28,7 +28,10 @@ export default function TableOfContents() {
       <TOCList>
         {trail.map((style, i) => {
           const chapter = bookData[i];
-          const action = chapter.type === 'project' ? 'visit' : 'view';
+          const action = chapter.type === 'project' ? 'visit'
+            : chapter.type === 'work' ? 'view'
+            : 'view';
+          const isExternal = chapter.type === 'work';
           return (
             <animated.div
               key={chapter.id}
@@ -38,7 +41,7 @@ export default function TableOfContents() {
               }}
             >
               <TOCEntry>
-                <Link to={`/chapter/${chapter.id}`}>
+                <Link to={isExternal ? chapter.href : `/chapter/${chapter.id}`}>
                   <TOCNumber>{String(chapter.chapter).padStart(2, '0')}</TOCNumber>
                   <TOCTitle>{chapter.title}</TOCTitle>
                   <TOCDotLeader />

--- a/src/TitlePage.js
+++ b/src/TitlePage.js
@@ -39,20 +39,34 @@ export default function TitlePage() {
         <EnterLink as={Link} to="/contents">
           Enter
         </EnterLink>
-        <Link
-          to="/admin"
-          style={{
-            marginTop: 48,
-            fontFamily: "'Space Mono', monospace",
-            fontSize: '0.65rem',
-            letterSpacing: '0.1em',
-            textTransform: 'uppercase',
-            color: '#D4C5A9',
-            textDecoration: 'none',
-          }}
-        >
-          Admin
-        </Link>
+        <div style={{ marginTop: 48, display: 'flex', gap: 32, justifyContent: 'center', alignItems: 'center' }}>
+          <Link
+            to="/work"
+            style={{
+              fontFamily: "'Space Mono', monospace",
+              fontSize: '0.68rem',
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#8B4513',
+              textDecoration: 'none',
+            }}
+          >
+            Work for Hire
+          </Link>
+          <Link
+            to="/admin"
+            style={{
+              fontFamily: "'Space Mono', monospace",
+              fontSize: '0.65rem',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: '#D4C5A9',
+              textDecoration: 'none',
+            }}
+          >
+            Admin
+          </Link>
+        </div>
       </animated.div>
     </BookPage>
   );

--- a/src/WorkPage.js
+++ b/src/WorkPage.js
@@ -160,31 +160,50 @@ const EmailLink = styled.a`
 
 const sites = [
   {
-    id: 'sculpt-swagger',
-    name: 'Sculpt & Swagger',
-    tagline: 'Chrome extension landing page',
+    id: 'homewise',
+    name: 'Homewise',
+    tagline: 'Mortgage brokerage platform',
     description:
-      'A product marketing site for a Chrome extension. Clean single-page layout designed to convert visitors into installs.',
-    stack: ['React', 'CSS'],
-    url: '#', // TODO: replace with live URL
+      'The digital front door for a Canadian mortgage brokerage. Fully bilingual (EN/FR), with product analytics via PostHog and error tracking through Sentry. CI/CD on AWS CodeBuild.',
+    stack: ['Next.js', 'MUI', 'i18next', 'PostHog', 'AWS'],
+    url: 'https://thinkhomewise.com',
   },
   {
-    id: 'thinkhomewise',
-    name: 'Think Homewise',
-    tagline: 'Real estate research platform',
+    id: 'homewise-real-estate',
+    name: 'Homewise Real Estate',
+    tagline: 'Real estate listings & neighbourhood data',
     description:
-      'A homebuying research tool for Canadians. Surfaces neighbourhood data, school ratings, and commute estimates to help buyers make confident decisions.',
-    stack: ['React', 'Firebase'],
-    url: 'https://thinkhomewise.com',
+      'A map-driven property search tool with Leaflet and Google Maps layered views, Cognito-based auth, and schema validation via AJV. End-to-end tested with Cypress, deployed through AWS CodeBuild.',
+    stack: ['React 18', 'MUI', 'Leaflet', 'Cognito', 'Cypress', 'AWS'],
+    url: 'https://thinkhomewise.com/real-estate',
+  },
+  {
+    id: 'sculpt-swagger',
+    name: 'Sculpt & Swagger',
+    tagline: 'Dance fitness studio',
+    description:
+      'Website for a dance fitness studio. Class schedules, instructor bios, and online booking — designed to reflect the energy of the brand.',
+    stack: ['Next.js', 'Sanity CMS', 'Tailwind'],
+    url: 'https://sculptandswagger.com',
+  },
+  {
+    id: 'reddit-research',
+    name: 'Reddit Research Assistant',
+    tagline: 'Chrome extension for content research',
+    description:
+      'A browser extension that helps marketers and writers mine Reddit threads for content insights, audience language, and topic ideas.',
+    stack: ['Chrome Extension', 'JavaScript'],
+    url: 'https://chromewebstore.google.com/detail/reddit-research-assistant/koknmoejnkchdpghejlifncpeddfhhnl',
+    linkLabel: 'View in Chrome Web Store',
   },
   {
     id: 'janus',
     name: 'Janus',
-    tagline: 'TODO: add tagline',
+    tagline: 'Web analytics for small projects',
     description:
-      'TODO: add a one-line description of what Janus does and who it is for.',
-    stack: [],
-    url: '#', // TODO: replace with live URL
+      'A full-stack analytics platform with a Tufte-inspired UI — high data-ink ratio, tables over charts, minimal chrome. Prisma over Postgres, Redis for caching and rate-limiting, JWT auth with token refresh, and transactional email via Resend. Frontend on Cloudflare Pages, backend secured with Helmet.',
+    stack: ['Fastify', 'React', 'TypeScript', 'Vite', 'PostgreSQL', 'Redis'],
+    url: 'https://addjanus.ca',
   },
 ];
 
@@ -214,14 +233,11 @@ export default function WorkPage() {
 
         <div style={{ marginTop: 40, marginBottom: 32, textAlign: 'center' }}>
           <PageTitle>Work for Hire</PageTitle>
-          <PageSubtitle>Websites, tools, and interfaces</PageSubtitle>
+          <PageSubtitle>Ships that left the harbour</PageSubtitle>
         </div>
 
         <Intro>
-          I build for the web — clean, purposeful, and fast to ship. Whether you need
-          a landing page to launch a product, a web app for your customers, or a
-          portfolio to represent your work, I take projects from brief to live.
-          Below is a record of sites currently in the world.
+          I design, build, and ship web products. Platforms, tools, extensions — brief to production. Here is the live work.
         </Intro>
 
         <HorizontalRule style={{ maxWidth: '100%', margin: '36px 0' }} />
@@ -252,7 +268,7 @@ export default function WorkPage() {
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      Visit site
+                      {site.linkLabel || 'Visit site'}
                     </VisitLink>
                   )}
                 </SiteEntry>
@@ -267,9 +283,7 @@ export default function WorkPage() {
 
         <CommissionBlock>
           <CommissionBody>
-            I work with individuals and small businesses. If you have a project in
-            mind — a new site, a rebuild, or something you haven't quite named yet —
-            send me a note and we can talk scope and timeline. No pitch decks required.
+            Have a project? Send a note. No decks, no calls — just scope and a timeline.
           </CommissionBody>
           <EmailLink href="mailto:bj.blayney@gmail.com">
             Get in touch

--- a/src/WorkPage.js
+++ b/src/WorkPage.js
@@ -1,0 +1,285 @@
+import React from 'react';
+import { useSpring, useTrail, animated } from '@react-spring/web';
+import { Link } from 'react-router-dom';
+import {
+  BookPage,
+  BackLink,
+  HorizontalRule,
+  ExternalLink,
+} from './styles';
+import styled from 'styled-components';
+
+const CREAM = '#FAF6F0';
+const INK = '#2C2C2C';
+const BROWN = '#8B4513';
+const TAN = '#D4C5A9';
+
+const PageTitle = styled.h1`
+  font-family: 'EB Garamond', serif;
+  font-size: 2.6rem;
+  font-weight: 700;
+  color: ${INK};
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  margin: 0 0 10px;
+
+  @media (max-width: 600px) {
+    font-size: 2rem;
+  }
+`;
+
+const PageSubtitle = styled.p`
+  font-family: 'EB Garamond', serif;
+  font-size: 1.2rem;
+  font-style: italic;
+  text-align: center;
+  color: ${BROWN};
+  margin: 0 0 32px;
+`;
+
+const Intro = styled.p`
+  font-family: 'EB Garamond', serif;
+  font-size: 1.15rem;
+  line-height: 1.8;
+  color: ${INK};
+  margin: 0;
+`;
+
+const SectionLabel = styled.p`
+  font-family: 'Space Mono', monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: ${TAN};
+  margin: 0 0 24px;
+`;
+
+const SiteList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+`;
+
+const SiteEntry = styled.div`
+  padding: 20px 0;
+  border-bottom: 1px solid ${TAN};
+
+  &:first-child {
+    border-top: 1px solid ${TAN};
+  }
+`;
+
+const SiteName = styled.h2`
+  font-family: 'EB Garamond', serif;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: ${INK};
+  margin: 0 0 4px;
+`;
+
+const SiteTagline = styled.p`
+  font-family: 'Space Mono', monospace;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: ${BROWN};
+  margin: 0 0 10px;
+`;
+
+const SiteDescription = styled.p`
+  font-family: 'EB Garamond', serif;
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: #555;
+  margin: 0 0 14px;
+`;
+
+const SiteStack = styled.p`
+  font-family: 'Space Mono', monospace;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${TAN};
+  margin: 0;
+`;
+
+const VisitLink = styled.a`
+  display: inline-block;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: ${BROWN};
+  text-decoration: none;
+  margin-top: 14px;
+  transition: color 0.15s;
+
+  &::after {
+    content: '\\00a0\\2192';
+  }
+
+  &:hover {
+    color: ${INK};
+  }
+`;
+
+const CommissionBlock = styled.div`
+  margin: 8px 0 0;
+`;
+
+const CommissionBody = styled.p`
+  font-family: 'EB Garamond', serif;
+  font-size: 1.15rem;
+  line-height: 1.8;
+  color: ${INK};
+  margin: 0 0 24px;
+`;
+
+const EmailLink = styled.a`
+  display: inline-block;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: ${BROWN};
+  text-decoration: none;
+  padding: 12px 28px;
+  border: 1px solid ${TAN};
+  transition: border-color 0.2s, background-color 0.2s;
+
+  &:hover {
+    border-color: ${BROWN};
+    background-color: rgba(139, 69, 19, 0.04);
+  }
+
+  &::before {
+    content: '\\2192\\00a0';
+  }
+`;
+
+const sites = [
+  {
+    id: 'sculpt-swagger',
+    name: 'Sculpt & Swagger',
+    tagline: 'Chrome extension landing page',
+    description:
+      'A product marketing site for a Chrome extension. Clean single-page layout designed to convert visitors into installs.',
+    stack: ['React', 'CSS'],
+    url: '#', // TODO: replace with live URL
+  },
+  {
+    id: 'thinkhomewise',
+    name: 'Think Homewise',
+    tagline: 'Real estate research platform',
+    description:
+      'A homebuying research tool for Canadians. Surfaces neighbourhood data, school ratings, and commute estimates to help buyers make confident decisions.',
+    stack: ['React', 'Firebase'],
+    url: 'https://thinkhomewise.com',
+  },
+  {
+    id: 'janus',
+    name: 'Janus',
+    tagline: 'TODO: add tagline',
+    description:
+      'TODO: add a one-line description of what Janus does and who it is for.',
+    stack: [],
+    url: '#', // TODO: replace with live URL
+  },
+];
+
+export default function WorkPage() {
+  const fade = useSpring({
+    from: { opacity: 0, y: 16 },
+    to: { opacity: 1, y: 0 },
+    config: { tension: 140, friction: 16 },
+  });
+
+  const trail = useTrail(sites.length, {
+    from: { opacity: 0, y: 10 },
+    to: { opacity: 1, y: 0 },
+    delay: 200,
+    config: { tension: 180, friction: 20 },
+  });
+
+  return (
+    <BookPage>
+      <animated.div
+        style={{
+          opacity: fade.opacity,
+          transform: fade.y.to((y) => `translateY(${y}px)`),
+        }}
+      >
+        <BackLink as={Link} to="/contents">Back to Contents</BackLink>
+
+        <div style={{ marginTop: 40, marginBottom: 32, textAlign: 'center' }}>
+          <PageTitle>Work for Hire</PageTitle>
+          <PageSubtitle>Websites, tools, and interfaces</PageSubtitle>
+        </div>
+
+        <Intro>
+          I build for the web — clean, purposeful, and fast to ship. Whether you need
+          a landing page to launch a product, a web app for your customers, or a
+          portfolio to represent your work, I take projects from brief to live.
+          Below is a record of sites currently in the world.
+        </Intro>
+
+        <HorizontalRule style={{ maxWidth: '100%', margin: '36px 0' }} />
+
+        <SectionLabel>Live work</SectionLabel>
+
+        <SiteList>
+          {trail.map((style, i) => {
+            const site = sites[i];
+            return (
+              <animated.div
+                key={site.id}
+                style={{
+                  opacity: style.opacity,
+                  transform: style.y.to((y) => `translateY(${y}px)`),
+                }}
+              >
+                <SiteEntry>
+                  <SiteName>{site.name}</SiteName>
+                  <SiteTagline>{site.tagline}</SiteTagline>
+                  <SiteDescription>{site.description}</SiteDescription>
+                  {site.stack.length > 0 && (
+                    <SiteStack>Stack: {site.stack.join(', ')}</SiteStack>
+                  )}
+                  {site.url !== '#' && (
+                    <VisitLink
+                      href={site.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Visit site
+                    </VisitLink>
+                  )}
+                </SiteEntry>
+              </animated.div>
+            );
+          })}
+        </SiteList>
+
+        <HorizontalRule style={{ maxWidth: '100%', margin: '40px 0 36px' }} />
+
+        <SectionLabel>Commission a site</SectionLabel>
+
+        <CommissionBlock>
+          <CommissionBody>
+            I work with individuals and small businesses. If you have a project in
+            mind — a new site, a rebuild, or something you haven't quite named yet —
+            send me a note and we can talk scope and timeline. No pitch decks required.
+          </CommissionBody>
+          <EmailLink href="mailto:bj.blayney@gmail.com">
+            Get in touch
+          </EmailLink>
+        </CommissionBlock>
+
+        <HorizontalRule style={{ maxWidth: '100%', margin: '48px 0 32px' }} />
+
+        <BackLink as={Link} to="/contents">Back to Contents</BackLink>
+      </animated.div>
+    </BookPage>
+  );
+}

--- a/src/bookData.js
+++ b/src/bookData.js
@@ -75,6 +75,14 @@ const bookData = [
     date: '2024',
     type: 'demo',
   },
+  {
+    id: 'work-for-hire',
+    chapter: 7,
+    title: 'Work for Hire',
+    subtitle: 'Websites built for the world',
+    type: 'work',
+    href: '/work',
+  },
 ];
 
 export default bookData;


### PR DESCRIPTION
## Summary

- **Fix photo gallery image loading on mobile** — adds shimmer skeletons during fetch, proper error handling with user-visible messages, per-image load/error state with fallback copy, `loading="lazy"` for progressive loading, and `alt` text fallback to filename
- **Add Work for Hire page** (`#/work`) — showcases live sites (Sculpt & Swagger, Think Homewise, Janus) with a commission CTA linking to `bj.blayney@gmail.com`; accessible from the title page and as Chapter 07 in the Table of Contents

## Test plan

- [ ] Visit the Photo Gallery chapter on a phone browser — skeletons should appear immediately, then images fade in as they load
- [ ] Disconnect network mid-load and confirm an error message appears instead of a blank gallery
- [ ] Visit `#/work` — confirm all three site entries render, Think Homewise "Visit site" link opens correctly, and "Get in touch" opens the mail client
- [ ] Check the title page — "Work for Hire" link should appear in brown beside the tan "Admin" link
- [ ] Check the Table of Contents — Chapter 07 "Work for Hire" should be present and link to `#/work`
- [ ] Fill in placeholder URLs and descriptions for Sculpt & Swagger and Janus in `src/WorkPage.js` before deploying

https://claude.ai/code/session_01343hs5zXQkNZ3aByA3jHrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01343hs5zXQkNZ3aByA3jHrD)_